### PR TITLE
updated Clang and CMake versions

### DIFF
--- a/dockers/ubuntu-14.04/Dockerfile
+++ b/dockers/ubuntu-14.04/Dockerfile
@@ -23,19 +23,19 @@ RUN apt-get update \
     build-essential \
  && rm -rf /var/lib/apt/lists/*
 
-# Install clang 7.0
+# Install clang 8.0
 RUN add-apt-repository ppa:ubuntu-toolchain-r/test -y \
  && cd /tmp \
  && wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
- && add-apt-repository "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-7 main" -y \
+ && add-apt-repository "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-8 main" -y \
  && apt-get update \
  && apt-get install -y --no-install-recommends \
-    clang-7 \
-    libomp-7-dev \
+    clang-8 \
+    libomp-8-dev \
  && rm -rf /var/lib/apt/lists/*
 
 # Install CMake
-RUN curl -sL https://cmake.org/files/v3.15/cmake-3.15.0-Linux-x86_64.sh -o cmake.sh \
+RUN curl -sL https://cmake.org/files/v3.15/cmake-3.15.3-Linux-x86_64.sh -o cmake.sh \
  && chmod +x cmake.sh \
  && ./cmake.sh --prefix=/usr/local --exclude-subdir \
  && rm cmake.sh


### PR DESCRIPTION
Clang 8 is stable now: https://apt.llvm.org.

Tested, works fine:

![image](https://user-images.githubusercontent.com/25141164/65066122-713d4380-d98c-11e9-832e-94ad06ffde92.png)
