### PR TITLE
[R-package] [ci] added R setup

### DIFF
--- a/dockers/ubuntu-14.04/Dockerfile
+++ b/dockers/ubuntu-14.04/Dockerfile
@@ -87,6 +87,7 @@ RUN add-apt-repository \
         --no-install-recommends \
         -y \
             r-base-dev=3.6.1-3trusty2 \
+            pandoc \
             texlive-latex-recommended \
             texlive-fonts-recommended \
             texlive-fonts-extra \

--- a/dockers/ubuntu-14.04/Dockerfile
+++ b/dockers/ubuntu-14.04/Dockerfile
@@ -73,8 +73,24 @@ RUN curl -sL https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.
  && /opt/conda/bin/conda install mkl qt -q -y \
  && /opt/conda/bin/conda clean -a -y \
  && chmod -R 777 /opt/conda
- 
+
 ENV CONDA=/opt/conda/
+
+# Install R
+RUN add-apt-repository \
+        "deb https://cloud.r-project.org/bin/linux/ubuntu trusty-cran35/" \
+    && apt-key adv \
+        --keyserver keyserver.ubuntu.com \
+        --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9 \
+    && apt-get update \
+    && apt-get install \
+        --no-install-recommends \
+        -y \
+            r-base-dev=3.6.1-3trusty2 \
+            texlive-latex-recommended \
+            texlive-fonts-recommended \
+            texlive-fonts-extra \
+            qpdf
 
 # Clean system
 RUN apt-get clean \


### PR DESCRIPTION
Adding setup of an R environment for steps being introduced in Microsoft/LightGBM#2530. This avoids needing to code around different Ubuntu distributions in the code used for LightGBM's Travis set up.