### PR TITLE
add texinfo package to image

### DIFF
--- a/dockers/ubuntu-14.04/Dockerfile
+++ b/dockers/ubuntu-14.04/Dockerfile
@@ -88,6 +88,7 @@ RUN add-apt-repository \
         -y \
             r-base-dev=3.6.1-3trusty2 \
             pandoc \
+            texinfo \
             texlive-latex-recommended \
             texlive-fonts-recommended \
             texlive-fonts-extra \


### PR DESCRIPTION
See the errors in `Linux r_package` stage on Azure DevOps for Microsoft/LightGBM#2530

https://dev.azure.com/lightgbm-ci/lightgbm-ci/_build/results?buildId=3693

![image](https://user-images.githubusercontent.com/7608904/70111231-35269000-1617-11ea-9922-0292c2b85d2c.png)

installing `texinfo` should fix this, as it did for the Linux builds on Travis side.