### PR TITLE
updated CMake version

### DIFF
--- a/dockers/ubuntu-14.04/Dockerfile
+++ b/dockers/ubuntu-14.04/Dockerfile
@@ -23,17 +23,17 @@ RUN apt-get update \
     build-essential \
  && rm -rf /var/lib/apt/lists/*
 
-# Install clang 9.0
+# Install clang 8.0
 RUN add-apt-repository ppa:ubuntu-toolchain-r/test -y \
  && cd /tmp \
  && wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
- && add-apt-repository "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-9 main" -y \
+ && add-apt-repository "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-8 main" -y \
  && apt-get update \
  && apt-get install -y --no-install-recommends \
-    clang-9 \
-    libomp-9-dev \
- && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-9 100 \
- && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-9 100 \
+    clang-8 \
+    libomp-8-dev \
+ && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-8 100 \
+ && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-8 100 \
  && rm -rf /var/lib/apt/lists/*
 
 # Install CMake

--- a/dockers/ubuntu-14.04/Dockerfile
+++ b/dockers/ubuntu-14.04/Dockerfile
@@ -23,21 +23,21 @@ RUN apt-get update \
     build-essential \
  && rm -rf /var/lib/apt/lists/*
 
-# Install clang 8.0
+# Install clang 9.0
 RUN add-apt-repository ppa:ubuntu-toolchain-r/test -y \
  && cd /tmp \
  && wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
- && add-apt-repository "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-8 main" -y \
+ && add-apt-repository "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-9 main" -y \
  && apt-get update \
  && apt-get install -y --no-install-recommends \
-    clang-8 \
-    libomp-8-dev \
- && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-8 100 \
- && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-8 100 \
+    clang-9 \
+    libomp-9-dev \
+ && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-9 100 \
+ && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-9 100 \
  && rm -rf /var/lib/apt/lists/*
 
 # Install CMake
-RUN curl -sL https://cmake.org/files/v3.15/cmake-3.15.3-Linux-x86_64.sh -o cmake.sh \
+RUN curl -sL https://cmake.org/files/v3.16/cmake-3.16.0-Linux-x86_64.sh -o cmake.sh \
  && chmod +x cmake.sh \
  && ./cmake.sh --prefix=/usr/local --exclude-subdir \
  && rm cmake.sh


### PR DESCRIPTION
Clang 9 is stable now: https://apt.llvm.org, but they dropped support for Ubuntu Trusty. So we cannot easily bump version anymore. I'll think about other options for installation of new versions.

> Precise, Quantal, Raring, Saucy, Utopic, Artful and Trusty are no longer supported by Ubuntu. Repo remains available


New CMake has been tested and works fine:

![image](https://user-images.githubusercontent.com/25141164/70406315-5c36f480-1a51-11ea-80cf-713cf9054e56.png)
