### PR TITLE
remove R (#11)

### DIFF
--- a/dockers/ubuntu-14.04/Dockerfile
+++ b/dockers/ubuntu-14.04/Dockerfile
@@ -82,24 +82,6 @@ RUN curl -sL https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.
 
 ENV CONDA=/opt/conda/
 
-# Install R
-RUN add-apt-repository \
-        "deb https://cloud.r-project.org/bin/linux/ubuntu trusty-cran35/" \
-    && apt-key adv \
-        --keyserver keyserver.ubuntu.com \
-        --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9 \
-    && apt-get update \
-    && apt-get install \
-        --no-install-recommends \
-        -y \
-            r-base-dev=3.6.3-1trusty \
-            pandoc \
-            texinfo \
-            texlive-latex-recommended \
-            texlive-fonts-recommended \
-            texlive-fonts-extra \
-            qpdf
-
 # Clean system
 RUN apt-get clean \
  && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
Docker image was built successfully:

![image](https://user-images.githubusercontent.com/25141164/88409862-37c03a80-cdde-11ea-85b1-a14a9c2643a8.png)


LightGBM seems to be passing all tests with new image quite well:

![image](https://user-images.githubusercontent.com/25141164/88411464-a8685680-cde0-11ea-8d4d-589d01da0c76.png)


cc @jameslamb