### PR TITLE
update SWIG

### DIFF
--- a/dockers/ubuntu-14.04/Dockerfile
+++ b/dockers/ubuntu-14.04/Dockerfile
@@ -73,15 +73,15 @@ ENV JAVA_HOME_8_X64=/usr/lib/jvm/zulu-8-amd64
 ENV JAVA_HOME=$JAVA_HOME_8_X64
 
 # Install SWIG
-RUN curl -sL https://downloads.sourceforge.net/project/swig/swig/swig-3.0.12/swig-3.0.12.tar.gz -o swig.tar.gz \
+RUN curl -sL https://sourceforge.net/projects/swig/files/swig/swig-4.0.2/swig-4.0.2.tar.gz/download -o swig.tar.gz \
  && tar -xzf swig.tar.gz \
- && cd swig-3.0.12 \
+ && cd swig-4.0.2 \
  && ./configure --prefix=/usr/local --without-pcre \
  && make \
  && make install \
  && cd .. \
  && rm swig.tar.gz \
- && rm -rf swig-3.0.12
+ && rm -rf swig-4.0.2
 
 # Install Miniconda
 RUN curl -sL https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -o miniconda.sh \


### PR DESCRIPTION
Continuation of https://github.com/microsoft/LightGBM/pull/3727.

Tried with `dev` and with both compilers `gcc` and `Clang`:

![image](https://user-images.githubusercontent.com/25141164/105061129-353b5680-5a8a-11eb-8210-43aabda78ed3.png)

```
2021-01-19T15:43:23.6761061Z -- The C compiler identification is GNU 4.8.4
2021-01-19T15:43:23.7248861Z -- The CXX compiler identification is GNU 4.8.4
2021-01-19T15:43:23.7332953Z -- Detecting C compiler ABI info
2021-01-19T15:43:23.7722579Z -- Detecting C compiler ABI info - done
2021-01-19T15:43:23.7819341Z -- Check for working C compiler: /usr/bin/cc - skipped
2021-01-19T15:43:23.7820360Z -- Detecting C compile features
2021-01-19T15:43:23.7826297Z -- Detecting C compile features - done
2021-01-19T15:43:23.7866103Z -- Detecting CXX compiler ABI info
2021-01-19T15:43:23.8317202Z -- Detecting CXX compiler ABI info - done
2021-01-19T15:43:23.8417714Z -- Check for working CXX compiler: /usr/bin/c++ - skipped
2021-01-19T15:43:23.8420082Z -- Detecting CXX compile features
2021-01-19T15:43:23.8944476Z -- Detecting CXX compile features - done
2021-01-19T15:43:23.9779289Z -- Found SWIG: /usr/local/bin/swig (found version "4.0.2")  
2021-01-19T15:43:24.0253223Z -- Found Java: /usr/lib/jvm/zulu-8-amd64/bin/java (found version "1.8.0_262") 
2021-01-19T15:43:24.0346008Z -- Found JNI: /usr/lib/jvm/zulu-8-amd64/jre/lib/amd64/libjawt.so  
2021-01-19T15:43:24.1825730Z -- Found OpenMP_C: -fopenmp (found version "3.1") 
2021-01-19T15:43:24.2336867Z -- Found OpenMP_CXX: -fopenmp (found version "3.1") 
2021-01-19T15:43:24.2341981Z -- Found OpenMP: TRUE (found version "3.1")  
2021-01-19T15:43:24.2351889Z -- Performing Test MM_PREFETCH
2021-01-19T15:43:24.2984095Z -- Performing Test MM_PREFETCH - Success
2021-01-19T15:43:24.2985114Z -- Using _mm_prefetch
2021-01-19T15:43:24.2988247Z -- Performing Test MM_MALLOC
2021-01-19T15:43:24.3518561Z -- Performing Test MM_MALLOC - Success
2021-01-19T15:43:24.3519426Z -- Using _mm_malloc
2021-01-19T15:43:24.3531323Z CMake Deprecation Warning at /usr/local/share/cmake-3.19/Modules/UseSWIG.cmake:620 (message):
2021-01-19T15:43:24.3532997Z   SWIG_ADD_MODULE is deprecated.  Use SWIG_ADD_LIBRARY instead.
2021-01-19T15:43:24.3534220Z Call Stack (most recent call first):
2021-01-19T15:43:24.3535152Z   CMakeLists.txt:351 (swig_add_module)
2021-01-19T15:43:24.3535921Z 
2021-01-19T15:43:24.3536649Z 
2021-01-19T15:43:24.3538040Z CMake Warning (dev) at /usr/local/share/cmake-3.19/Modules/UseSWIG.cmake:661 (message):
2021-01-19T15:43:24.3538814Z   Policy CMP0078 is not set: UseSWIG generates standard target names.  Run
2021-01-19T15:43:24.3539706Z   "cmake --help-policy CMP0078" for policy details.  Use the cmake_policy
2021-01-19T15:43:24.3540266Z   command to set the policy and suppress this warning.
2021-01-19T15:43:24.3581650Z 
2021-01-19T15:43:24.3584496Z Call Stack (most recent call first):
2021-01-19T15:43:24.3585649Z   /usr/local/share/cmake-3.19/Modules/UseSWIG.cmake:621 (swig_add_library)
2021-01-19T15:43:24.3586996Z   CMakeLists.txt:351 (swig_add_module)
2021-01-19T15:43:24.3587834Z This warning is for project developers.  Use -Wno-dev to suppress it.
2021-01-19T15:43:24.3588110Z 
2021-01-19T15:43:24.3588687Z CMake Warning (dev) at /usr/local/share/cmake-3.19/Modules/UseSWIG.cmake:513 (message):
2021-01-19T15:43:24.3589354Z   Policy CMP0086 is not set: UseSWIG honors SWIG_MODULE_NAME via -module
2021-01-19T15:43:24.3589971Z   flag.  Run "cmake --help-policy CMP0086" for policy details.  Use the
2021-01-19T15:43:24.3590382Z   cmake_policy command to set the policy and suppress this warning.
2021-01-19T15:43:24.3590614Z 
2021-01-19T15:43:24.3662757Z Call Stack (most recent call first):
2021-01-19T15:43:24.3664195Z   /usr/local/share/cmake-3.19/Modules/UseSWIG.cmake:764 (SWIG_ADD_SOURCE_TO_MODULE)
2021-01-19T15:43:24.3665256Z   /usr/local/share/cmake-3.19/Modules/UseSWIG.cmake:621 (swig_add_library)
2021-01-19T15:43:24.3665882Z   CMakeLists.txt:351 (swig_add_module)
2021-01-19T15:43:24.3666773Z This warning is for project developers.  Use -Wno-dev to suppress it.
2021-01-19T15:43:24.3667394Z 
2021-01-19T15:43:24.3667946Z -- Configuring done
2021-01-19T15:43:24.3709582Z -- Generating done
2021-01-19T15:43:24.3720473Z -- Build files have been written to: /__w/1/s/build
2021-01-19T15:43:24.3884072Z Scanning dependencies of target _lightgbm_swig_swig_compilation
2021-01-19T15:43:24.3913066Z [  1%] Swig compile swig/lightgbmlib.i for java
2021-01-19T15:43:24.4951379Z Scanning dependencies of target _lightgbm
2021-01-19T15:43:24.4955333Z Scanning dependencies of target lightgbm
2021-01-19T15:43:24.5046079Z [  4%] Building CXX object CMakeFiles/_lightgbm.dir/src/boosting/boosting.cpp.o
2021-01-19T15:43:24.5047098Z [  4%] Building CXX object CMakeFiles/lightgbm.dir/src/main.cpp.o
2021-01-19T15:43:24.5059943Z [  5%] Building CXX object CMakeFiles/lightgbm.dir/src/application/application.cpp.o
2021-01-19T15:43:24.7605095Z [  5%] Built target _lightgbm_swig_swig_compilation
2021-01-19T15:43:24.7631076Z [  6%] Building CXX object CMakeFiles/_lightgbm.dir/src/boosting/gbdt.cpp.o
2021-01-19T15:43:26.0280964Z [  8%] Building CXX object CMakeFiles/lightgbm.dir/src/boosting/boosting.cpp.o
2021-01-19T15:43:30.2961731Z [  9%] Building CXX object CMakeFiles/_lightgbm.dir/src/boosting/gbdt_model_text.cpp.o
2021-01-19T15:43:30.4782006Z [ 11%] Building CXX object CMakeFiles/lightgbm.dir/src/boosting/gbdt.cpp.o
2021-01-19T15:43:30.6222361Z [ 12%] Building CXX object CMakeFiles/_lightgbm.dir/src/boosting/gbdt_prediction.cpp.o
2021-01-19T15:43:31.7510988Z [ 13%] Building CXX object CMakeFiles/lightgbm.dir/src/boosting/gbdt_model_text.cpp.o
2021-01-19T15:43:32.9922941Z [ 15%] Building CXX object CMakeFiles/_lightgbm.dir/src/boosting/prediction_early_stop.cpp.o
2021-01-19T15:43:33.5419180Z [ 16%] Building CXX object CMakeFiles/_lightgbm.dir/src/io/bin.cpp.o
2021-01-19T15:43:35.3496273Z [ 18%] Building CXX object CMakeFiles/_lightgbm.dir/src/io/config.cpp.o
2021-01-19T15:43:36.3962564Z [ 19%] Building CXX object CMakeFiles/lightgbm.dir/src/boosting/gbdt_prediction.cpp.o
2021-01-19T15:43:36.8016778Z [ 20%] Building CXX object CMakeFiles/lightgbm.dir/src/boosting/prediction_early_stop.cpp.o
2021-01-19T15:43:37.3907774Z [ 22%] Building CXX object CMakeFiles/lightgbm.dir/src/io/bin.cpp.o
2021-01-19T15:43:38.7615405Z [ 23%] Building CXX object CMakeFiles/lightgbm.dir/src/io/config.cpp.o
2021-01-19T15:43:39.6180036Z [ 25%] Building CXX object CMakeFiles/_lightgbm.dir/src/io/config_auto.cpp.o
2021-01-19T15:43:42.8722185Z [ 26%] Building CXX object CMakeFiles/lightgbm.dir/src/io/config_auto.cpp.o
2021-01-19T15:43:43.5414632Z [ 27%] Building CXX object CMakeFiles/_lightgbm.dir/src/io/dataset.cpp.o
2021-01-19T15:43:46.7882836Z [ 29%] Building CXX object CMakeFiles/lightgbm.dir/src/io/dataset.cpp.o
2021-01-19T15:43:51.2882466Z [ 30%] Building CXX object CMakeFiles/_lightgbm.dir/src/io/dataset_loader.cpp.o
2021-01-19T15:43:52.7161450Z [ 31%] Building CXX object CMakeFiles/_lightgbm.dir/src/io/file_io.cpp.o
2021-01-19T15:43:53.3587933Z [ 33%] Building CXX object CMakeFiles/_lightgbm.dir/src/io/json11.cpp.o
2021-01-19T15:43:54.7689548Z [ 34%] Building CXX object CMakeFiles/_lightgbm.dir/src/io/metadata.cpp.o
2021-01-19T15:43:56.2134282Z [ 36%] Building CXX object CMakeFiles/_lightgbm.dir/src/io/parser.cpp.o
2021-01-19T15:43:56.8392923Z [ 37%] Building CXX object CMakeFiles/lightgbm.dir/src/io/dataset_loader.cpp.o
2021-01-19T15:43:58.3344918Z [ 38%] Building CXX object CMakeFiles/_lightgbm.dir/src/io/train_share_states.cpp.o
2021-01-19T15:43:59.0250756Z [ 40%] Building CXX object CMakeFiles/_lightgbm.dir/src/io/tree.cpp.o
2021-01-19T15:43:59.0714746Z [ 41%] Building CXX object CMakeFiles/_lightgbm.dir/src/metric/dcg_calculator.cpp.o
2021-01-19T15:44:00.2312582Z [ 43%] Building CXX object CMakeFiles/_lightgbm.dir/src/metric/metric.cpp.o
2021-01-19T15:44:01.8024047Z [ 44%] Building CXX object CMakeFiles/_lightgbm.dir/src/network/ifaddrs_patch.cpp.o
2021-01-19T15:44:01.8228926Z [ 45%] Building CXX object CMakeFiles/_lightgbm.dir/src/network/linker_topo.cpp.o
2021-01-19T15:44:03.3736139Z [ 47%] Building CXX object CMakeFiles/_lightgbm.dir/src/network/linkers_mpi.cpp.o
2021-01-19T15:44:03.3937485Z [ 48%] Building CXX object CMakeFiles/_lightgbm.dir/src/network/linkers_socket.cpp.o
2021-01-19T15:44:04.1556292Z [ 50%] Building CXX object CMakeFiles/lightgbm.dir/src/io/file_io.cpp.o
2021-01-19T15:44:04.7661494Z [ 51%] Building CXX object CMakeFiles/lightgbm.dir/src/io/json11.cpp.o
2021-01-19T15:44:06.7979405Z [ 52%] Building CXX object CMakeFiles/_lightgbm.dir/src/network/network.cpp.o
2021-01-19T15:44:07.6018458Z [ 54%] Building CXX object CMakeFiles/lightgbm.dir/src/io/metadata.cpp.o
2021-01-19T15:44:08.9157119Z [ 55%] Building CXX object CMakeFiles/_lightgbm.dir/src/objective/objective_function.cpp.o
2021-01-19T15:44:09.2983428Z [ 56%] Building CXX object CMakeFiles/_lightgbm.dir/src/treelearner/cuda_tree_learner.cpp.o
2021-01-19T15:44:09.3184973Z [ 58%] Building CXX object CMakeFiles/_lightgbm.dir/src/treelearner/data_parallel_tree_learner.cpp.o
2021-01-19T15:44:09.9155018Z [ 59%] Building CXX object CMakeFiles/_lightgbm.dir/src/treelearner/feature_parallel_tree_learner.cpp.o
2021-01-19T15:44:11.5941111Z [ 61%] Building CXX object CMakeFiles/lightgbm.dir/src/io/parser.cpp.o
2021-01-19T15:44:14.5235110Z [ 62%] Building CXX object CMakeFiles/_lightgbm.dir/src/treelearner/gpu_tree_learner.cpp.o
2021-01-19T15:44:14.5440400Z [ 63%] Building CXX object CMakeFiles/_lightgbm.dir/src/treelearner/linear_tree_learner.cpp.o
2021-01-19T15:44:14.5886843Z [ 65%] Building CXX object CMakeFiles/lightgbm.dir/src/io/train_share_states.cpp.o
2021-01-19T15:44:15.0092938Z [ 66%] Building CXX object CMakeFiles/_lightgbm.dir/src/treelearner/serial_tree_learner.cpp.o
2021-01-19T15:44:16.5343519Z [ 68%] Building CXX object CMakeFiles/lightgbm.dir/src/io/tree.cpp.o
2021-01-19T15:44:16.6636149Z [ 69%] Building CXX object CMakeFiles/_lightgbm.dir/src/treelearner/tree_learner.cpp.o
2021-01-19T15:44:20.7927553Z [ 70%] Building CXX object CMakeFiles/_lightgbm.dir/src/treelearner/voting_parallel_tree_learner.cpp.o
2021-01-19T15:44:26.3693421Z [ 72%] Building CXX object CMakeFiles/lightgbm.dir/src/metric/dcg_calculator.cpp.o
2021-01-19T15:44:27.2347014Z [ 73%] Building CXX object CMakeFiles/_lightgbm.dir/src/c_api.cpp.o
2021-01-19T15:44:29.0855707Z [ 75%] Building CXX object CMakeFiles/lightgbm.dir/src/metric/metric.cpp.o
2021-01-19T15:44:36.9203623Z [ 76%] Building CXX object CMakeFiles/lightgbm.dir/src/network/ifaddrs_patch.cpp.o
2021-01-19T15:44:36.9407779Z [ 77%] Building CXX object CMakeFiles/lightgbm.dir/src/network/linker_topo.cpp.o
2021-01-19T15:44:38.6664544Z [ 80%] Building CXX object CMakeFiles/lightgbm.dir/src/network/linkers_socket.cpp.o
2021-01-19T15:44:38.6665917Z [ 80%] Building CXX object CMakeFiles/lightgbm.dir/src/network/linkers_mpi.cpp.o
2021-01-19T15:44:38.6882159Z [ 81%] Building CXX object CMakeFiles/lightgbm.dir/src/network/network.cpp.o
2021-01-19T15:44:41.2231118Z [ 83%] Building CXX object CMakeFiles/lightgbm.dir/src/objective/objective_function.cpp.o
2021-01-19T15:44:42.1303078Z [ 84%] Building CXX object CMakeFiles/lightgbm.dir/src/treelearner/cuda_tree_learner.cpp.o
2021-01-19T15:44:42.1510822Z [ 86%] Building CXX object CMakeFiles/lightgbm.dir/src/treelearner/data_parallel_tree_learner.cpp.o
2021-01-19T15:44:45.4682118Z [ 87%] Building CXX object CMakeFiles/lightgbm.dir/src/treelearner/feature_parallel_tree_learner.cpp.o
2021-01-19T15:44:47.8269256Z [ 88%] Building CXX object CMakeFiles/lightgbm.dir/src/treelearner/gpu_tree_learner.cpp.o
2021-01-19T15:44:47.8475178Z [ 90%] Building CXX object CMakeFiles/lightgbm.dir/src/treelearner/linear_tree_learner.cpp.o
2021-01-19T15:44:48.9219724Z [ 91%] Building CXX object CMakeFiles/lightgbm.dir/src/treelearner/serial_tree_learner.cpp.o
2021-01-19T15:44:49.8700950Z [ 93%] Linking CXX shared library ../lib_lightgbm.so
2021-01-19T15:44:49.9165106Z [ 94%] Building CXX object CMakeFiles/lightgbm.dir/src/treelearner/tree_learner.cpp.o
2021-01-19T15:44:50.1954674Z [ 94%] Built target _lightgbm
2021-01-19T15:44:50.2081172Z Scanning dependencies of target _lightgbm_swig
2021-01-19T15:44:50.2126265Z [ 95%] Building CXX object CMakeFiles/_lightgbm_swig.dir/java/lightgbmlibJAVA_wrap.cxx.o
2021-01-19T15:44:52.5260027Z [ 97%] Linking CXX shared module ../lib_lightgbm_swig.so
2021-01-19T15:44:54.2246054Z [ 98%] Building CXX object CMakeFiles/lightgbm.dir/src/treelearner/voting_parallel_tree_learner.cpp.o
2021-01-19T15:44:54.3570577Z [ 98%] Built target _lightgbm_swig
2021-01-19T15:45:13.1205587Z [100%] Linking CXX executable ../lightgbm
2021-01-19T15:45:13.3217062Z [100%] Built target lightgbm
```

```
2021-01-19T16:06:56.2961806Z -- The C compiler identification is Clang 9.0.0
2021-01-19T16:06:56.6880226Z -- The CXX compiler identification is Clang 9.0.0
2021-01-19T16:06:56.6962565Z -- Detecting C compiler ABI info
2021-01-19T16:06:56.7395424Z -- Detecting C compiler ABI info - done
2021-01-19T16:06:56.7483391Z -- Check for working C compiler: /usr/local/bin/clang - skipped
2021-01-19T16:06:56.7484834Z -- Detecting C compile features
2021-01-19T16:06:56.7490382Z -- Detecting C compile features - done
2021-01-19T16:06:56.7531213Z -- Detecting CXX compiler ABI info
2021-01-19T16:06:56.8068026Z -- Detecting CXX compiler ABI info - done
2021-01-19T16:06:56.8161519Z -- Check for working CXX compiler: /usr/local/bin/clang++ - skipped
2021-01-19T16:06:56.8162798Z -- Detecting CXX compile features
2021-01-19T16:06:56.8169675Z -- Detecting CXX compile features - done
2021-01-19T16:06:56.8996144Z -- Found SWIG: /usr/local/bin/swig (found version "4.0.2")  
2021-01-19T16:06:56.9442089Z -- Found Java: /usr/lib/jvm/zulu-8-amd64/bin/java (found version "1.8.0_262") 
2021-01-19T16:06:56.9533188Z -- Found JNI: /usr/lib/jvm/zulu-8-amd64/jre/lib/amd64/libjawt.so  
2021-01-19T16:06:57.1346682Z -- Found OpenMP_C: -fopenmp=libomp (found version "3.1") 
2021-01-19T16:06:57.2030156Z -- Found OpenMP_CXX: -fopenmp=libomp (found version "3.1") 
2021-01-19T16:06:57.2034583Z -- Found OpenMP: TRUE (found version "3.1")  
2021-01-19T16:06:57.2041496Z -- Performing Test MM_PREFETCH
2021-01-19T16:06:57.2920413Z -- Performing Test MM_PREFETCH - Success
2021-01-19T16:06:57.2921617Z -- Using _mm_prefetch
2021-01-19T16:06:57.2925368Z -- Performing Test MM_MALLOC
2021-01-19T16:06:57.3553712Z -- Performing Test MM_MALLOC - Success
2021-01-19T16:06:57.3554932Z -- Using _mm_malloc
2021-01-19T16:06:57.3571272Z CMake Deprecation Warning at /usr/local/share/cmake-3.19/Modules/UseSWIG.cmake:620 (message):
2021-01-19T16:06:57.3572135Z   SWIG_ADD_MODULE is deprecated.  Use SWIG_ADD_LIBRARY instead.
2021-01-19T16:06:57.3572610Z Call Stack (most recent call first):
2021-01-19T16:06:57.3572919Z   CMakeLists.txt:351 (swig_add_module)
2021-01-19T16:06:57.3573137Z 
2021-01-19T16:06:57.3573318Z 
2021-01-19T16:06:57.3573886Z CMake Warning (dev) at /usr/local/share/cmake-3.19/Modules/UseSWIG.cmake:661 (message):
2021-01-19T16:06:57.3574293Z   Policy CMP0078 is not set: UseSWIG generates standard target names.  Run
2021-01-19T16:06:57.3574897Z   "cmake --help-policy CMP0078" for policy details.  Use the cmake_policy
2021-01-19T16:06:57.3575310Z   command to set the policy and suppress this warning.
2021-01-19T16:06:57.3575507Z 
2021-01-19T16:06:57.3575784Z Call Stack (most recent call first):
2021-01-19T16:06:57.3576291Z   /usr/local/share/cmake-3.19/Modules/UseSWIG.cmake:621 (swig_add_library)
2021-01-19T16:06:57.3576631Z   CMakeLists.txt:351 (swig_add_module)
2021-01-19T16:06:57.3577173Z This warning is for project developers.  Use -Wno-dev to suppress it.
2021-01-19T16:06:57.3577409Z 
2021-01-19T16:06:57.3591056Z CMake Warning (dev) at /usr/local/share/cmake-3.19/Modules/UseSWIG.cmake:513 (message):
2021-01-19T16:06:57.3591918Z   Policy CMP0086 is not set: UseSWIG honors SWIG_MODULE_NAME via -module
2021-01-19T16:06:57.3592470Z   flag.  Run "cmake --help-policy CMP0086" for policy details.  Use the
2021-01-19T16:06:57.3592901Z   cmake_policy command to set the policy and suppress this warning.
2021-01-19T16:06:57.3593111Z 
2021-01-19T16:06:57.3593391Z Call Stack (most recent call first):
2021-01-19T16:06:57.3593924Z   /usr/local/share/cmake-3.19/Modules/UseSWIG.cmake:764 (SWIG_ADD_SOURCE_TO_MODULE)
2021-01-19T16:06:57.3594542Z   /usr/local/share/cmake-3.19/Modules/UseSWIG.cmake:621 (swig_add_library)
2021-01-19T16:06:57.3594870Z   CMakeLists.txt:351 (swig_add_module)
2021-01-19T16:06:57.3595358Z This warning is for project developers.  Use -Wno-dev to suppress it.
2021-01-19T16:06:57.3595730Z 
2021-01-19T16:06:57.3602322Z -- Configuring done
2021-01-19T16:06:57.3739467Z -- Generating done
2021-01-19T16:06:57.3751354Z -- Build files have been written to: /__w/1/s/build
2021-01-19T16:06:57.3934783Z Scanning dependencies of target _lightgbm_swig_swig_compilation
2021-01-19T16:06:57.4076538Z [  1%] Swig compile swig/lightgbmlib.i for java
2021-01-19T16:06:57.4540105Z Scanning dependencies of target _lightgbm
2021-01-19T16:06:57.4602054Z [  2%] Building CXX object CMakeFiles/_lightgbm.dir/src/boosting/boosting.cpp.o
2021-01-19T16:06:57.4609696Z [  4%] Building CXX object CMakeFiles/_lightgbm.dir/src/boosting/gbdt.cpp.o
2021-01-19T16:06:57.4842979Z Scanning dependencies of target lightgbm
2021-01-19T16:06:57.4928561Z [  5%] Building CXX object CMakeFiles/lightgbm.dir/src/main.cpp.o
2021-01-19T16:06:57.8104855Z [  5%] Built target _lightgbm_swig_swig_compilation
2021-01-19T16:06:57.8130141Z [  6%] Building CXX object CMakeFiles/_lightgbm.dir/src/boosting/gbdt_model_text.cpp.o
2021-01-19T16:06:59.1567956Z [  8%] Building CXX object CMakeFiles/lightgbm.dir/src/application/application.cpp.o
2021-01-19T16:07:01.2197310Z [  9%] Building CXX object CMakeFiles/_lightgbm.dir/src/boosting/gbdt_prediction.cpp.o
2021-01-19T16:07:02.3575158Z [ 11%] Building CXX object CMakeFiles/_lightgbm.dir/src/boosting/prediction_early_stop.cpp.o
2021-01-19T16:07:02.3728968Z [ 12%] Building CXX object CMakeFiles/_lightgbm.dir/src/io/bin.cpp.o
2021-01-19T16:07:03.3262021Z [ 13%] Building CXX object CMakeFiles/_lightgbm.dir/src/io/config.cpp.o
2021-01-19T16:07:03.3794836Z [ 15%] Building CXX object CMakeFiles/lightgbm.dir/src/boosting/boosting.cpp.o
2021-01-19T16:07:04.2423140Z [ 16%] Building CXX object CMakeFiles/_lightgbm.dir/src/io/config_auto.cpp.o
2021-01-19T16:07:06.9091118Z [ 18%] Building CXX object CMakeFiles/_lightgbm.dir/src/io/dataset.cpp.o
2021-01-19T16:07:07.1237125Z [ 19%] Building CXX object CMakeFiles/lightgbm.dir/src/boosting/gbdt.cpp.o
2021-01-19T16:07:08.4708984Z [ 20%] Building CXX object CMakeFiles/_lightgbm.dir/src/io/dataset_loader.cpp.o
2021-01-19T16:07:11.9934007Z [ 22%] Building CXX object CMakeFiles/lightgbm.dir/src/boosting/gbdt_model_text.cpp.o
2021-01-19T16:07:13.3502434Z [ 23%] Building CXX object CMakeFiles/_lightgbm.dir/src/io/file_io.cpp.o
2021-01-19T16:07:14.1777934Z [ 25%] Building CXX object CMakeFiles/_lightgbm.dir/src/io/json11.cpp.o
2021-01-19T16:07:14.3109074Z [ 26%] Building CXX object CMakeFiles/_lightgbm.dir/src/io/metadata.cpp.o
2021-01-19T16:07:16.0194415Z [ 27%] Building CXX object CMakeFiles/_lightgbm.dir/src/io/parser.cpp.o
2021-01-19T16:07:16.5813639Z [ 29%] Building CXX object CMakeFiles/_lightgbm.dir/src/io/train_share_states.cpp.o
2021-01-19T16:07:16.6440662Z [ 30%] Building CXX object CMakeFiles/lightgbm.dir/src/boosting/gbdt_prediction.cpp.o
2021-01-19T16:07:17.3253599Z [ 31%] Building CXX object CMakeFiles/_lightgbm.dir/src/io/tree.cpp.o
2021-01-19T16:07:18.4475039Z [ 33%] Building CXX object CMakeFiles/_lightgbm.dir/src/metric/dcg_calculator.cpp.o
2021-01-19T16:07:18.7875138Z [ 34%] Building CXX object CMakeFiles/lightgbm.dir/src/boosting/prediction_early_stop.cpp.o
2021-01-19T16:07:18.8309903Z [ 36%] Building CXX object CMakeFiles/_lightgbm.dir/src/metric/metric.cpp.o
2021-01-19T16:07:19.7408382Z [ 37%] Building CXX object CMakeFiles/lightgbm.dir/src/io/bin.cpp.o
2021-01-19T16:07:20.9339623Z [ 38%] Building CXX object CMakeFiles/_lightgbm.dir/src/network/ifaddrs_patch.cpp.o
2021-01-19T16:07:20.9568919Z [ 40%] Building CXX object CMakeFiles/_lightgbm.dir/src/network/linker_topo.cpp.o
2021-01-19T16:07:22.7685691Z [ 41%] Building CXX object CMakeFiles/_lightgbm.dir/src/network/linkers_mpi.cpp.o
2021-01-19T16:07:22.7925484Z [ 43%] Building CXX object CMakeFiles/_lightgbm.dir/src/network/linkers_socket.cpp.o
2021-01-19T16:07:24.9160841Z [ 44%] Building CXX object CMakeFiles/_lightgbm.dir/src/network/network.cpp.o
2021-01-19T16:07:26.1620967Z [ 45%] Building CXX object CMakeFiles/_lightgbm.dir/src/objective/objective_function.cpp.o
2021-01-19T16:07:26.1724451Z [ 47%] Building CXX object CMakeFiles/_lightgbm.dir/src/treelearner/cuda_tree_learner.cpp.o
2021-01-19T16:07:26.1947331Z [ 48%] Building CXX object CMakeFiles/_lightgbm.dir/src/treelearner/data_parallel_tree_learner.cpp.o
2021-01-19T16:07:26.9969950Z [ 50%] Building CXX object CMakeFiles/_lightgbm.dir/src/treelearner/feature_parallel_tree_learner.cpp.o
2021-01-19T16:07:30.9630641Z [ 51%] Building CXX object CMakeFiles/_lightgbm.dir/src/treelearner/gpu_tree_learner.cpp.o
2021-01-19T16:07:30.9856000Z [ 52%] Building CXX object CMakeFiles/_lightgbm.dir/src/treelearner/linear_tree_learner.cpp.o
2021-01-19T16:07:31.1818890Z [ 54%] Building CXX object CMakeFiles/_lightgbm.dir/src/treelearner/serial_tree_learner.cpp.o
2021-01-19T16:07:32.4158696Z [ 55%] Building CXX object CMakeFiles/_lightgbm.dir/src/treelearner/tree_learner.cpp.o
2021-01-19T16:07:33.7167607Z [ 56%] Building CXX object CMakeFiles/lightgbm.dir/src/io/config.cpp.o
2021-01-19T16:07:35.9389269Z [ 58%] Building CXX object CMakeFiles/_lightgbm.dir/src/treelearner/voting_parallel_tree_learner.cpp.o
2021-01-19T16:07:37.2670696Z [ 59%] Building CXX object CMakeFiles/lightgbm.dir/src/io/config_auto.cpp.o
2021-01-19T16:07:41.0496288Z [ 61%] Building CXX object CMakeFiles/_lightgbm.dir/src/c_api.cpp.o
2021-01-19T16:07:41.5138823Z [ 62%] Building CXX object CMakeFiles/lightgbm.dir/src/io/dataset.cpp.o
2021-01-19T16:07:47.9657430Z [ 63%] Building CXX object CMakeFiles/lightgbm.dir/src/io/dataset_loader.cpp.o
2021-01-19T16:07:49.2609896Z [ 65%] Building CXX object CMakeFiles/lightgbm.dir/src/io/file_io.cpp.o
2021-01-19T16:07:50.2238122Z [ 66%] Building CXX object CMakeFiles/lightgbm.dir/src/io/json11.cpp.o
2021-01-19T16:07:52.0335258Z [ 68%] Building CXX object CMakeFiles/lightgbm.dir/src/io/metadata.cpp.o
2021-01-19T16:07:53.6409359Z [ 69%] Building CXX object CMakeFiles/lightgbm.dir/src/io/parser.cpp.o
2021-01-19T16:07:54.9499740Z [ 70%] Building CXX object CMakeFiles/lightgbm.dir/src/io/train_share_states.cpp.o
2021-01-19T16:07:55.2293231Z [ 72%] Building CXX object CMakeFiles/lightgbm.dir/src/io/tree.cpp.o
2021-01-19T16:07:56.0347796Z [ 73%] Building CXX object CMakeFiles/lightgbm.dir/src/metric/dcg_calculator.cpp.o
2021-01-19T16:07:57.1767740Z [ 75%] Building CXX object CMakeFiles/lightgbm.dir/src/metric/metric.cpp.o
2021-01-19T16:07:58.5637143Z [ 76%] Building CXX object CMakeFiles/lightgbm.dir/src/network/ifaddrs_patch.cpp.o
2021-01-19T16:07:58.6936057Z [ 77%] Building CXX object CMakeFiles/lightgbm.dir/src/network/linker_topo.cpp.o
2021-01-19T16:07:58.9574731Z [ 79%] Linking CXX shared library ../lib_lightgbm.so
2021-01-19T16:07:59.2526476Z [ 79%] Built target _lightgbm
2021-01-19T16:07:59.2640833Z Scanning dependencies of target _lightgbm_swig
2021-01-19T16:07:59.2677353Z [ 80%] Building CXX object CMakeFiles/_lightgbm_swig.dir/java/lightgbmlibJAVA_wrap.cxx.o
2021-01-19T16:08:00.5128239Z [ 81%] Building CXX object CMakeFiles/lightgbm.dir/src/network/linkers_mpi.cpp.o
2021-01-19T16:08:00.5359247Z [ 83%] Building CXX object CMakeFiles/lightgbm.dir/src/network/linkers_socket.cpp.o
2021-01-19T16:08:01.4721277Z [ 84%] Linking CXX shared module ../lib_lightgbm_swig.so
2021-01-19T16:08:03.2622570Z [ 86%] Building CXX object CMakeFiles/lightgbm.dir/src/network/network.cpp.o
2021-01-19T16:08:03.2668104Z [ 86%] Built target _lightgbm_swig
2021-01-19T16:08:03.2692431Z [ 87%] Building CXX object CMakeFiles/lightgbm.dir/src/objective/objective_function.cpp.o
2021-01-19T16:08:03.5745073Z [ 88%] Building CXX object CMakeFiles/lightgbm.dir/src/treelearner/cuda_tree_learner.cpp.o
2021-01-19T16:08:03.5978249Z [ 90%] Building CXX object CMakeFiles/lightgbm.dir/src/treelearner/data_parallel_tree_learner.cpp.o
2021-01-19T16:08:03.8412639Z [ 91%] Building CXX object CMakeFiles/lightgbm.dir/src/treelearner/feature_parallel_tree_learner.cpp.o
2021-01-19T16:08:05.7542587Z [ 93%] Building CXX object CMakeFiles/lightgbm.dir/src/treelearner/gpu_tree_learner.cpp.o
2021-01-19T16:08:05.7550124Z [ 94%] Building CXX object CMakeFiles/lightgbm.dir/src/treelearner/linear_tree_learner.cpp.o
2021-01-19T16:08:07.7200722Z [ 95%] Building CXX object CMakeFiles/lightgbm.dir/src/treelearner/serial_tree_learner.cpp.o
2021-01-19T16:08:08.5171141Z [ 97%] Building CXX object CMakeFiles/lightgbm.dir/src/treelearner/tree_learner.cpp.o
2021-01-19T16:08:09.4915143Z [ 98%] Building CXX object CMakeFiles/lightgbm.dir/src/treelearner/voting_parallel_tree_learner.cpp.o
2021-01-19T16:08:25.7325972Z [100%] Linking CXX executable ../lightgbm
2021-01-19T16:08:25.9231036Z [100%] Built target lightgbm
```