### PR TITLE
Restore Docker autobuilds on repo pushes via GitHub Actions

### DIFF
--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -1,0 +1,34 @@
+name: Publish Docker image
+
+on:
+  push:
+    branches:
+    - master
+    - dev
+
+jobs:
+  push_to_docker_hub:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2.3.4
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1.10.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Extract tag for Docker
+        id: tag
+        shell: bash
+        run: |
+            branch=${GITHUB_REF#refs/heads/}
+            docker_tag=ubuntu-14.04-${branch}
+            docker_tag=${docker_tag%-master}
+            echo "::set-output name=docker_tag::${docker_tag}"
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2.7.0
+        with:
+          context: ${{ github.workspace }}/dockers/ubuntu-14.04/
+          push: true
+          tags: lightgbm/vsts-agent:${{ steps.tag.outputs.docker_tag }}

--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v2
       - name: Log in to Docker Hub
-        uses: docker/login-action@v1.10.0
+        uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -27,7 +27,7 @@ jobs:
             docker_tag=${docker_tag%-master}
             echo "::set-output name=docker_tag::${docker_tag}"
       - name: Build and push Docker image
-        uses: docker/build-push-action@v2.7.0
+        uses: docker/build-push-action@v2
         with:
           context: ${{ github.workspace }}/dockers/ubuntu-14.04/
           push: true


### PR DESCRIPTION
Closed #18.

GitHub Actions logs: https://github.com/guolinke/lightgbm-ci-docker/runs/3641088439?check_suite_focus=true.

Push to Docker Hub succeeded: https://hub.docker.com/layers/40251340/lightgbm/vsts-agent/ubuntu-14.04-dev/images/sha256-10e440ae8683e5a0694bd4978bc0ce77a2f5ab0ff176a1540e75065eeeec6edc?context=repo.

![image](https://user-images.githubusercontent.com/25141164/133897277-76b1fa3d-a386-4c3c-bf3d-b7cf435b5c81.png)

Azure builds were successful with recently uploaded Docker file:

![image](https://user-images.githubusercontent.com/25141164/133898384-c373abb2-330b-4e97-b71e-515b7cab2a97.png)


![image](https://user-images.githubusercontent.com/25141164/133897297-6e6a5366-c3dd-4a4f-9a06-d8822440f5d4.png)


cc @jameslamb 