### PR TITLE
add mambaforge installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # lightgbm-ci-docker
 
-This project is used to build container images that can be used to test LightGBM in operating systems not supported by continouus integration services.
+This project is used to build container images that can be used to test LightGBM in operating systems not supported by continuous integration services.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # lightgbm-ci-docker
-This is the docker for LightGBM CI
+
+This project is used to build container images that can be used to test LightGBM in operating systems not supported by continouus integration services.

--- a/dockers/ubuntu-14.04/.dockerignore
+++ b/dockers/ubuntu-14.04/.dockerignore
@@ -1,0 +1,2 @@
+*
+!start_azure.sh

--- a/dockers/ubuntu-14.04/Dockerfile
+++ b/dockers/ubuntu-14.04/Dockerfile
@@ -84,11 +84,10 @@ RUN curl -sLk https://sourceforge.net/projects/swig/files/swig/swig-4.0.2/swig-4
  && rm -rf swig-4.0.2
 
 # Install Miniconda
-RUN curl -sL https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -o miniconda.sh \
+RUN curl -sL "https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Linux-$(uname -m).sh" -o miniconda.sh \
  && chmod +x miniconda.sh \
  && ./miniconda.sh -b -p /opt/conda \
  && rm miniconda.sh \
- && /opt/conda/bin/conda install python=3 -q -y \
  && /opt/conda/bin/conda clean -a -y \
  && chmod -R 777 /opt/conda
 

--- a/dockers/ubuntu-14.04/Dockerfile
+++ b/dockers/ubuntu-14.04/Dockerfile
@@ -83,15 +83,15 @@ RUN curl -sLk https://sourceforge.net/projects/swig/files/swig/swig-4.0.2/swig-4
  && rm swig.tar.gz \
  && rm -rf swig-4.0.2
 
-# Install Miniconda
-RUN curl -sL "https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Linux-$(uname -m).sh" -o miniconda.sh \
- && chmod +x miniconda.sh \
- && ./miniconda.sh -b -p /opt/conda \
- && rm miniconda.sh \
- && /opt/conda/bin/conda clean -a -y \
- && chmod -R 777 /opt/conda
+# Install mamba[forge]
+RUN curl -sL "https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Linux-$(uname -m).sh" -o mambaforge.sh \
+ && chmod +x mambaforge.sh \
+ && ./mambaforge.sh -b -p /opt/mamba \
+ && rm mambaforge.sh \
+ && /opt/mamba/bin/conda clean -a -y \
+ && chmod -R 777 /opt/mamba
 
-ENV CONDA=/opt/conda/
+ENV CONDA=/opt/mamba/
 
 # Clean system
 RUN apt-get clean \


### PR DESCRIPTION
Contributes to https://github.com/microsoft/LightGBM/issues/4948.

This PR proposes adding support for using `mamba` instead of `conda` to install conda packages.

### How I tested this

```shell
cd dockers/ubuntu-14.04
docker build \
    -t lightgbm/vsts-agent:local \
    -f ./Dockerfile \
    .
```

### Notes for Reviewers

I'd like to push these changes to the `dev` branch, and test pulling in the new image `lightgbm/vsts-agent:ubuntu-14.04-dev` pushed to Docker Hub on https://github.com/microsoft/LightGBM/pull/4953.

Per https://github.com/microsoft/LightGBM/issues/4948#issuecomment-1013950651, I don't have permissions to create branches here.

@StrikerRUS could you create a `dev` branch in this repo so I can target this PR at it?

@guolinke if you see this, could you please give me "write" permissions on this repo so I can add branches myself in the future?