### PR TITLE
update master with latest changes from dev

### DIFF
--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -10,6 +10,12 @@ jobs:
   push_to_docker_hub:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - docker_image: ubuntu-14.04
+          - docker_image: manylinux2014_aarch64
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -23,12 +29,12 @@ jobs:
         shell: bash
         run: |
             branch=${GITHUB_REF#refs/heads/}
-            docker_tag=ubuntu-14.04-${branch}
+            docker_tag=${{ matrix.docker_image }}-${branch}
             docker_tag=${docker_tag%-master}
             echo "::set-output name=docker_tag::${docker_tag}"
       - name: Build and push Docker image
         uses: docker/build-push-action@v2
         with:
-          context: ${{ github.workspace }}/dockers/ubuntu-14.04/
+          context: ${{ github.workspace }}/dockers/${{ matrix.docker_image }}/
           push: true
           tags: lightgbm/vsts-agent:${{ steps.tag.outputs.docker_tag }}

--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -5,6 +5,7 @@ on:
     branches:
     - master
     - dev
+    - dev2
 
 jobs:
   push_to_docker_hub:
@@ -18,6 +19,8 @@ jobs:
             arch: linux/amd64
           - docker_image: manylinux2014_aarch64
             arch: linux/arm64
+          - docker_image: manylinux_2_28_x86_64
+            arch: linux/amd64
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   push_to_docker_hub:
-    name: Push Docker image to Docker Hub
+    name: ${{ matrix.docker_image}} (${{ matrix.arch }}) - build and push
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Log in to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -38,7 +38,7 @@ jobs:
         uses: docker/setup-qemu-action@v2
         if: matrix.arch != 'linux/amd64'
       - name: Build and push Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: ${{ github.workspace }}/dockers/${{ matrix.docker_image }}/
           push: true

--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -15,7 +15,9 @@ jobs:
       matrix:
         include:
           - docker_image: ubuntu-14.04
+            arch: linux/amd64
           - docker_image: manylinux2014_aarch64
+            arch: linux/arm64
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -32,9 +34,13 @@ jobs:
             docker_tag=${{ matrix.docker_image }}-${branch}
             docker_tag=${docker_tag%-master}
             echo "::set-output name=docker_tag::${docker_tag}"
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        if: matrix.arch != 'linux/amd64'
       - name: Build and push Docker image
         uses: docker/build-push-action@v2
         with:
           context: ${{ github.workspace }}/dockers/${{ matrix.docker_image }}/
           push: true
+          platforms: ${{ matrix.arch }}
           tags: lightgbm/vsts-agent:${{ steps.tag.outputs.docker_tag }}

--- a/dockers/manylinux2014_aarch64/Dockerfile
+++ b/dockers/manylinux2014_aarch64/Dockerfile
@@ -1,0 +1,35 @@
+FROM quay.io/pypa/manylinux2014_aarch64
+
+RUN yum install -y \
+    epel-release \
+    gcc-c++ \
+    hwloc-devel \
+    sudo \
+ && yum clean all \
+ && rm -rf /var/cache/yum
+
+RUN yum install -y \
+    llvm-toolset-7.0-clang-devel \
+    llvm-toolset-7.0-llvm-devel \
+    ocl-icd-devel \
+ && yum clean all \
+ && rm -rf /var/cache/yum
+
+RUN git clone --depth 1 --branch v1.8 https://github.com/pocl/pocl.git \
+ && cmake \
+    -B pocl/build \
+    -S pocl \
+    -DCMAKE_BUILD_TYPE=release \
+    -DCMAKE_C_COMPILER=/usr/bin/gcc \
+    -DCMAKE_CXX_COMPILER=/usr/bin/g++ \
+    -DCMAKE_C_FLAGS=-std=gnu99 \
+    -DPOCL_INSTALL_ICD_VENDORDIR=/etc/OpenCL/vendors \
+    -DPOCL_DEBUG_MESSAGES=OFF \
+    -DINSTALL_OPENCL_HEADERS=OFF \
+    -DENABLE_SPIR=OFF \
+    -DENABLE_POCLCC=OFF \
+    -DENABLE_TESTS=OFF \
+    -DENABLE_EXAMPLES=OFF \
+    -DLLC_HOST_CPU=generic \
+ && cmake --build pocl/build -j4 \
+ && sudo cmake --install pocl/build

--- a/dockers/manylinux2014_aarch64/Dockerfile
+++ b/dockers/manylinux2014_aarch64/Dockerfile
@@ -1,6 +1,7 @@
 FROM quay.io/pypa/manylinux2014_aarch64
 
-RUN yum install -y \
+RUN yum update \
+ && yum install -y \
     epel-release \
     gcc-c++ \
     hwloc-devel \

--- a/dockers/manylinux2014_aarch64/Dockerfile
+++ b/dockers/manylinux2014_aarch64/Dockerfile
@@ -9,8 +9,7 @@ RUN yum update \
  && yum clean all \
  && rm -rf /var/cache/yum
 
-RUN yum update \
- && yum install -y \
+RUN yum install -y \
     llvm-toolset-7.0-clang-devel \
     llvm-toolset-7.0-llvm-devel \
     ocl-icd-devel \

--- a/dockers/manylinux2014_aarch64/Dockerfile
+++ b/dockers/manylinux2014_aarch64/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/pypa/manylinux2014_aarch64
 
-RUN yum update
-RUN yum install -y \
+RUN yum update \
+ && yum install -y \
     epel-release \
     gcc-c++ \
     hwloc-devel \
@@ -9,12 +9,16 @@ RUN yum install -y \
  && yum clean all \
  && rm -rf /var/cache/yum
 
-RUN yum install -y \
+RUN yum update \
+ && yum install -y \
     llvm-toolset-7.0-clang-devel \
     llvm-toolset-7.0-llvm-devel \
     ocl-icd-devel \
  && yum clean all \
  && rm -rf /var/cache/yum
+
+ENV LD_LIBRARY_PATH "/opt/rh/llvm-toolset-7.0/root/usr/lib64:${LD_LIBRARY_PATH}"
+ENV PATH "/opt/rh/llvm-toolset-7.0/root/usr/bin:${PATH}"
 
 RUN git clone --depth 1 --branch v1.8 https://github.com/pocl/pocl.git \
  && cmake \

--- a/dockers/manylinux2014_aarch64/Dockerfile
+++ b/dockers/manylinux2014_aarch64/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/pypa/manylinux2014_aarch64
 
-RUN yum update \
- && yum install -y \
+RUN yum update
+RUN yum install -y \
     epel-release \
     gcc-c++ \
     hwloc-devel \

--- a/dockers/manylinux_2_28_x86_64/.dockerignore
+++ b/dockers/manylinux_2_28_x86_64/.dockerignore
@@ -1,0 +1,2 @@
+*
+!start_azure.sh

--- a/dockers/manylinux_2_28_x86_64/Dockerfile
+++ b/dockers/manylinux_2_28_x86_64/Dockerfile
@@ -1,0 +1,130 @@
+FROM quay.io/pypa/manylinux_2_28_x86_64
+
+# ensure that libraries like libc++ built in this image can be found by the linker
+ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/lib:/usr/local/lib64"
+
+RUN yum update -y \
+ && yum install -y \
+    sudo \
+ && yum clean all
+
+# Install CMake
+RUN curl -sL https://cmake.org/files/v3.23/cmake-3.23.1-linux-x86_64.sh -o cmake.sh \
+ && chmod +x cmake.sh \
+ && ./cmake.sh --prefix=/usr/local --exclude-subdir \
+ && rm -f ./cmake.sh
+
+# building clang
+#
+# [why v11.1.0?]
+#
+# - LightGBM is incompatible with libomp v12 and v13 (https://github.com/microsoft/LightGBM/issues/4229)
+# - PoCL v1.8 requires LLVM+clang, but only supports v6-v13 (https://github.com/pocl/pocl/blob/3f420ef735672e439097d020db605778dbc4a6a1/cmake/LLVM.cmake#L209)
+# - so v11.x is the latest version that will work with the these constraints, and v11.1.0 was the last release in the v11 series
+#
+# [why from source?]
+#
+# - manylinux images use a custom sysroot foor the gcc toolchain, which doesn't play well with the precompiled llvm+clang available from https://github.com/llvm/llvm-project/releases
+# - there is not a precompiled llvm+clang available for x86_64 architecture + non-Ubuntu distributions
+#
+# [why are we building libcxx and lld?]
+#
+# - in case compilation with clang (e.g. of PoCL v1.8) uses libc++ instead of libstdc++
+#
+# https://clang.llvm.org/get_started.html
+# https://llvm.org/docs/GettingStarted.html#compiling-the-llvm-suite-source-code
+ARG CLANG_VER=11.1.0
+RUN mkdir /usr/local/src/clang \
+ && cd /usr/local/src/clang \
+ && git clone --depth 1 --branch llvmorg-$CLANG_VER https://github.com/llvm/llvm-project.git \
+ && cd llvm-project \
+ && mkdir build \
+ && cd build \
+ && cmake \
+     -DCMAKE_BUILD_TYPE=Release \
+     -DGCC_INSTALL_PREFIX=${DEVTOOLSET_ROOTPATH} \
+     -DLLVM_BUILD_BENCHMARKS=OFF \
+     -DLLVM_BUILD_DOCS=OFF \
+     -DLLVM_BUILD_TESTS=OFF \
+     -DLLVM_INCLUDE_BENCHMARKS=OFF \
+     -DLLVM_INCLUDE_DOCS=OFF \
+     -DLLVM_INCLUDE_TESTS=OFF \
+     -DLLVM_ENABLE_BINDINGS=OFF \
+     -DLLVM_ENABLE_DOXYGEN=OFF \
+     -DLLVM_ENABLE_OCAMLDOC=OFF \
+     -DLLVM_ENABLE_PROJECTS="clang;openmp" \
+     -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi" \
+     -DLLVM_ENABLE_SPHINX=OFF \
+     -DLLVM_TARGETS_TO_BUILD="X86" \
+     -G "Unix Makefiles" \
+     ../llvm \
+ && make -j2 \
+ && make install \
+ # `make install` places libc++ into a different directory,
+ # symlinking it into /usr/local/lib so the linker can find it
+ && cp -s /usr/local/lib/x86_64-unknown-linux-gnu/c++/* /usr/local/lib/ \
+ # manylinux images already come with an ldconfig rule pointing at /usr/local/lib,
+ # but just doing this explicitly to be safe in case they remove that in the future
+ && echo /usr/local/lib > /etc/ld.so.conf.d/llvm.conf \
+ && ldconfig \
+ && cd "${HOME}" \
+ && rm -rf /usr/local/src/clang
+
+# Install PoCL
+RUN git clone --depth 1 --branch v1.8 https://github.com/pocl/pocl.git \
+ && cmake \
+    -B pocl/build \
+    -S pocl \
+    -DCMAKE_BUILD_TYPE=release \
+    -DCMAKE_C_COMPILER=clang \
+    -DCMAKE_CXX_COMPILER=clang++ \
+    -DCMAKE_CXX_FLAGS=-stdlib=libstdc++ \
+    -DPOCL_INSTALL_ICD_VENDORDIR=/etc/OpenCL/vendors \
+    -DPOCL_DEBUG_MESSAGES=OFF \
+    -DSTATIC_LLVM=ON \
+    -DINSTALL_OPENCL_HEADERS=OFF \
+    -DENABLE_SPIR=OFF \
+    -DENABLE_POCLCC=OFF \
+    -DENABLE_TESTS=OFF \
+    -DENABLE_EXAMPLES=OFF \
+ && cmake --build pocl/build -j4 \
+ && cmake --install pocl/build \
+ && rm -f ./compile_test*.bc \
+ && rm -f ./compile_test*.o \
+ && rm -rf ./pocl
+
+# Install Java
+RUN yum install -y \
+      java-1.8.0-openjdk-devel.x86_64 \
+ && yum clean all
+
+ENV JAVA_HOME_8_X64=/usr/lib/jvm/java
+ENV JAVA_HOME=$JAVA_HOME_8_X64
+
+# Install SWIG
+RUN curl -sLk https://sourceforge.net/projects/swig/files/swig/swig-4.0.2/swig-4.0.2.tar.gz/download -o swig.tar.gz \
+ && tar -xzf swig.tar.gz \
+ && cd swig-4.0.2 \
+ && ./configure --prefix=/usr/local --without-pcre \
+ && make \
+ && make install \
+ && cd .. \
+ && rm -f ./swig.tar.gz \
+ && rm -rf ./swig-4.0.2
+
+# Install miniforge
+RUN curl -sL "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-$(uname -m).sh" -o miniforge.sh \
+ && chmod +x miniforge.sh \
+ && ./miniforge.sh -b -p /opt/miniforge \
+ && rm -f ./miniforge.sh \
+ && /opt/miniforge/bin/conda clean -a -y \
+ && chmod -R 777 /opt/miniforge
+
+ENV CONDA=/opt/miniforge/
+
+WORKDIR /vsts
+
+COPY ./start_azure.sh .
+RUN chmod +x start_azure.sh
+
+CMD ["./start_azure.sh"]

--- a/dockers/manylinux_2_28_x86_64/start_azure.sh
+++ b/dockers/manylinux_2_28_x86_64/start_azure.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+set -e
+
+export VSO_AGENT_IGNORE=_,MAIL,OLDPWD,PATH,PWD,VSTS_AGENT,VSTS_ACCOUNT,VSTS_TOKEN_FILE,VSTS_TOKEN,VSTS_POOL,VSTS_WORK,VSO_AGENT_IGNORE
+if [ -n "$VSTS_AGENT_IGNORE" ]; then
+  export VSO_AGENT_IGNORE=$VSO_AGENT_IGNORE,VSTS_AGENT_IGNORE,$VSTS_AGENT_IGNORE
+fi
+
+if [ -e /vsts/agent -a ! -e /vsts/.configure ]; then
+  trap 'kill -SIGINT $!; exit 130' INT
+  trap 'kill -SIGTERM $!; exit 143' TERM
+  /vsts/agent/bin/Agent.Listener run & wait $!
+  exit $?
+fi
+
+if [ -z "$VSTS_ACCOUNT" ]; then
+  echo 1>&2 error: missing VSTS_ACCOUNT environment variable
+  exit 1
+fi
+
+if [ -z "$VSTS_TOKEN_FILE" ]; then
+  if [ -z "$VSTS_TOKEN" ]; then
+    echo 1>&2 error: missing VSTS_TOKEN environment variable
+    exit 1
+  fi
+  VSTS_TOKEN_FILE=/vsts/.token
+  echo -n $VSTS_TOKEN > "$VSTS_TOKEN_FILE"
+fi
+unset VSTS_TOKEN
+
+if [ -n "$VSTS_AGENT" ]; then
+  export VSTS_AGENT="$(eval echo $VSTS_AGENT)"
+fi
+
+if [ -n "$VSTS_WORK" ]; then
+  export VSTS_WORK="$(eval echo $VSTS_WORK)"
+  mkdir -p "$VSTS_WORK"
+fi
+
+touch /vsts/.configure
+rm -rf /vsts/agent
+mkdir /vsts/agent
+cd /vsts/agent
+
+web-server() {
+  while true; do
+    printf 'HTTP/1.1 302 Found\r\nLocation: https://'$VSTS_ACCOUNT'.visualstudio.com/_admin/_AgentPool\r\n\r\n' | nc -l -p 80 -q 0 > /dev/null
+  done
+}
+
+cleanup() {
+  if [ -e config.sh ]; then
+    ./bin/Agent.Listener remove --unattended \
+      --auth PAT \
+      --token $(cat "$VSTS_TOKEN_FILE")
+  fi
+}
+
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
+
+echo Determining matching VSTS agent...
+VSTS_AGENT_RESPONSE=$(curl -LsS \
+  -u user:$(cat "$VSTS_TOKEN_FILE") \
+  -H 'Accept:application/json;api-version=3.0-preview' \
+  "https://$VSTS_ACCOUNT.visualstudio.com/_apis/distributedtask/packages/agent?platform=linux-x64")
+
+if echo "$VSTS_AGENT_RESPONSE" | jq . >/dev/null 2>&1; then
+  VSTS_AGENT_URL=$(echo "$VSTS_AGENT_RESPONSE" \
+    | jq -r '.value | map([.version.major,.version.minor,.version.patch,.downloadUrl]) | sort | .[length-1] | .[3]')
+fi
+
+if [ -z "$VSTS_AGENT_URL" -o "$VSTS_AGENT_URL" == "null" ]; then
+  echo 1>&2 error: could not determine a matching VSTS agent - check that account \'$VSTS_ACCOUNT\' is correct and the token is valid for that account
+  exit 1
+fi
+
+echo Downloading and installing VSTS agent...
+curl -LsS $VSTS_AGENT_URL | tar -xz --no-same-owner & wait $!
+
+source ./env.sh
+
+./bin/Agent.Listener configure --unattended \
+  --agent "${VSTS_AGENT:-$(hostname)}" \
+  --url "https://$VSTS_ACCOUNT.visualstudio.com" \
+  --auth PAT \
+  --token $(cat "$VSTS_TOKEN_FILE") \
+  --pool "${VSTS_POOL:-Default}" \
+  --work "${VSTS_WORK:-_work}" \
+  --replace & wait $!
+
+web-server &
+./bin/Agent.Listener run & wait $!


### PR DESCRIPTION
Opening this draft PR to track changes that have built up on `dev`.

This shouldn't be merged until https://github.com/microsoft/LightGBM/pull/5252 is.

* adding a `manylinux2014_aarch64` image supporting building integrated arm64 wheels
* modifying this project's GitHub Actions configuration to build and push multiple images
* updating to the latest version of all third-party actions used on GitHub Actions

<details><summary>why upgrade the third-party actions?</summary>

To resolve warnings like the ones seen on https://github.com/guolinke/lightgbm-ci-docker/actions/runs/3407833708

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, docker/login-action, docker/build-push-action, docker/build-push-action, docker/login-action, actions/checkout

> The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

> The `save-state` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

<img width="656" alt="image" src="https://user-images.githubusercontent.com/7608904/200357837-c056d22f-b78e-4493-bf2b-f6952b63ca87.png">

</details>