### PR TITLE
ensure PoCL finds newer OpenCL

### DIFF
--- a/dockers/manylinux2014_aarch64/Dockerfile
+++ b/dockers/manylinux2014_aarch64/Dockerfile
@@ -9,8 +9,7 @@ RUN yum update \
  && yum clean all \
  && rm -rf /var/cache/yum
 
-RUN yum update \
- && yum install -y \
+RUN yum install -y \
     llvm-toolset-7.0-clang-devel \
     llvm-toolset-7.0-llvm-devel \
     ocl-icd-devel \

--- a/dockers/manylinux2014_aarch64/Dockerfile
+++ b/dockers/manylinux2014_aarch64/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/pypa/manylinux2014_aarch64
 
-RUN yum update
-RUN yum install -y \
+RUN yum update \
+ && yum install -y \
     epel-release \
     gcc-c++ \
     hwloc-devel \
@@ -9,7 +9,8 @@ RUN yum install -y \
  && yum clean all \
  && rm -rf /var/cache/yum
 
-RUN yum install -y \
+RUN yum update \
+ && yum install -y \
     llvm-toolset-7.0-clang-devel \
     llvm-toolset-7.0-llvm-devel \
     ocl-icd-devel \

--- a/dockers/manylinux2014_aarch64/Dockerfile
+++ b/dockers/manylinux2014_aarch64/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/pypa/manylinux2014_aarch64
 
-RUN yum update \
- && yum install -y \
+RUN yum update
+RUN yum install -y \
     epel-release \
     gcc-c++ \
     hwloc-devel \

--- a/dockers/manylinux_2_28_x86_64/Dockerfile
+++ b/dockers/manylinux_2_28_x86_64/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/pypa/manylinux_2_28_x86_64
 
 # ensure that libraries like libc++ built in this image can be found by the linker
-ENV LD_LIBRARY_PATH="/usr/local/lib64:/usr/local/lib:${LD_LIBRARY_PATH}"
+ENV LD_LIBRARY_PATH="/usr/local/lib64:${LD_LIBRARY_PATH}:/usr/local/lib"
 
 RUN yum update -y \
  && yum install -y \

--- a/dockers/manylinux_2_28_x86_64/Dockerfile
+++ b/dockers/manylinux_2_28_x86_64/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/pypa/manylinux_2_28_x86_64
 
 # ensure that libraries like libc++ built in this image can be found by the linker
-ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/lib:/usr/local/lib64"
+ENV LD_LIBRARY_PATH="/usr/local/lib64:/usr/local/lib:${LD_LIBRARY_PATH}"
 
 RUN yum update -y \
  && yum install -y \
@@ -72,6 +72,10 @@ RUN mkdir /usr/local/src/clang \
 
 # Install PoCL
 RUN git clone --depth 1 --branch v1.8 https://github.com/pocl/pocl.git \
+ && yum update -y \
+ && yum install -y \
+    ocl-icd-devel \
+    opencl-headers \
  && cmake \
     -B pocl/build \
     -S pocl \
@@ -91,7 +95,8 @@ RUN git clone --depth 1 --branch v1.8 https://github.com/pocl/pocl.git \
  && cmake --install pocl/build \
  && rm -f ./compile_test*.bc \
  && rm -f ./compile_test*.o \
- && rm -rf ./pocl
+ && rm -rf ./pocl \
+ && yum clean all
 
 # Install Java
 RUN yum install -y \


### PR DESCRIPTION
Trying to fix https://github.com/microsoft/LightGBM/pull/5252#issuecomment-1321192047.

See the following in the logs for a recent build of the `manylinux_2_28_x86_64` image ([build link](https://github.com/guolinke/lightgbm-ci-docker/actions/runs/3511062623/jobs/5881476161)).

```text
Checking for module 'ocl-icd>=1.3'
  Package 'ocl-icd', required by 'virtual:world', not found
ocl-icd not found -> trying fallback ICD implementations
Checking for module 'OpenCL>=1.2'
  Package 'OpenCL', required by 'virtual:world', not found
No ICD loader of any kind found (or its OpenCL version is <1.2)
Using an ICD loader : 0
Run tests with ICD: 0
Not installing OpenCL headers.
Failed to find tcecc or tce-config, disabling TCE
TCE support : 0
```

That comes from this point in the `pocl` build: https://github.com/pocl/pocl/blob/765341f299058e973fd6ddfd7332cd58c042bc64/CMakeLists.txt#L1020-L1044

As described at https://github.com/KhronosGroup/OpenCL-ICD-Loader, and ICD is an "installable client driver". As described at http://portablecl.org/docs/html/using.html#linking-your-program-with-pocl-through-an-icd-loader, the idea is that LightGBM would use an OpenCL ICD loader that knows how to load PoCL, instead of linking against PoCL itself.

Not finding a working loader means that the PoCL build won't register itself as something OpenCL programs can use, resulting in the following error at runtime:

> lightgbm.basic.LightGBMError: No OpenCL device found