### PR TITLE
[ci] allow pushes from any branch

### DIFF
--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -1,11 +1,12 @@
 name: Publish Docker image
 
 on:
+  # Run manually by clicking a button in the UI
+  workflow_dispatch:
+  # Run automatically on new commits to specific branches
   push:
     branches:
     - master
-    - dev
-    - dev2
 
 jobs:
   push_to_docker_hub:
@@ -25,7 +26,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -38,10 +39,10 @@ jobs:
             docker_tag=${docker_tag%-master}
             echo "::set-output name=docker_tag::${docker_tag}"
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
         if: matrix.arch != 'linux/amd64'
       - name: Build and push Docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: ${{ github.workspace }}/dockers/${{ matrix.docker_image }}/
           push: true

--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -24,7 +24,7 @@ jobs:
             arch: linux/amd64
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
To test changes in this project today, you have to do the following:

1. push commits to the `dev` or `dev2` branch
2. wait for that automatically-triggered build(s) to complete
3. open a PR over in LightGBM switching the image(s) over to the new ones from that branch (e.g. `lightgbm/vsts-agent:ubuntu-14.04-dev`)
4. if all goes well, merge `dev` into `master` here

This PR proposes a different pattern that I think will make testing easier. It introduces a GitHub Actions `workflow_dispatch` event to trigger the workflow that builds and pushes images. That way, anyone who can create branches here (which should only be LightGBM maintainers) can just push changes to that branch and click a button to build new images. Those new images will then be tagged with that branch name, e.g. `lightgbm/vsts-agent:ubuntu-14.04-some-branch`.

This also proposes updating all third-party actions used here to their latest versions.

### Why I'm confident this will work

We do the same thing for the link-checker job over in LightGBM.

https://github.com/microsoft/LightGBM/blob/8ed371cee49cf86740b25dd9a4b985a75c9f2dba/.github/workflows/linkchecker.yml#L4-L5

<img width="1420" alt="Screen Shot 2023-10-20 at 11 23 33 PM" src="https://github.com/guolinke/lightgbm-ci-docker/assets/7608904/e9500be1-065d-42f8-9c3a-c9feeb5bfa5b">

### Notes for Reviewers

@guolinke could you make me an admin in this repo and add me to the `lightgbm` DockerHub organization (https://hub.docker.com/u/lightgbm)?

So that I can modify permissions and delete temporary testing images pushed to DockerHub.