### PR TITLE
WIP: [ci] use manylinux_2_28 for aarch64 builds

### DIFF
--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - docker_image: manylinux2014_aarch64
+          - docker_image: manylinux_2_28_aarch64
             arch: linux/arm64
           - docker_image: manylinux_2_28_x86_64
             arch: linux/amd64
@@ -40,7 +40,7 @@ jobs:
         uses: docker/setup-qemu-action@v3
         if: matrix.arch != 'linux/amd64'
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: ${{ github.workspace }}/images/${{ matrix.docker_image }}/
           push: true

--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -18,8 +18,8 @@ jobs:
         include:
           - docker_image: manylinux_2_28_aarch64
             arch: linux/arm64
-          - docker_image: manylinux_2_28_x86_64
-            arch: linux/amd64
+          # - docker_image: manylinux_2_28_x86_64
+          #   arch: linux/amd64
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/images/manylinux_2_28_aarch64/Dockerfile
+++ b/images/manylinux_2_28_aarch64/Dockerfile
@@ -1,23 +1,14 @@
-FROM quay.io/pypa/manylinux2014_aarch64
+FROM quay.io/pypa/manylinux_2_28_aarch64
 
-RUN yum update \
+RUN yum update -y \
  && yum install -y \
     epel-release \
     gcc-c++ \
     hwloc-devel \
+    ocl-icd-devel \
     sudo \
  && yum clean all \
  && rm -rf /var/cache/yum
-
-RUN yum install -y \
-    llvm-toolset-7.0-clang-devel \
-    llvm-toolset-7.0-llvm-devel \
-    ocl-icd-devel \
- && yum clean all \
- && rm -rf /var/cache/yum
-
-ENV LD_LIBRARY_PATH "/opt/rh/llvm-toolset-7.0/root/usr/lib64:${LD_LIBRARY_PATH}"
-ENV PATH "/opt/rh/llvm-toolset-7.0/root/usr/bin:${PATH}"
 
 RUN git clone --depth 1 --branch v1.8 https://github.com/pocl/pocl.git \
  && cmake \

--- a/images/manylinux_2_28_aarch64/Dockerfile
+++ b/images/manylinux_2_28_aarch64/Dockerfile
@@ -8,7 +8,7 @@ RUN yum update -y \
     ocl-icd-devel \
     sudo \
  && yum module install -y \
-      llvm-toolset
+      llvm-toolset \
  && yum clean all \
  && rm -rf /var/cache/yum
 

--- a/images/manylinux_2_28_aarch64/Dockerfile
+++ b/images/manylinux_2_28_aarch64/Dockerfile
@@ -5,9 +5,10 @@ RUN yum update -y \
     epel-release \
     gcc-c++ \
     hwloc-devel \
-    llvm-toolset \
     ocl-icd-devel \
     sudo \
+ && yum module install -y \
+      llvm-toolset
  && yum clean all \
  && rm -rf /var/cache/yum
 

--- a/images/manylinux_2_28_aarch64/Dockerfile
+++ b/images/manylinux_2_28_aarch64/Dockerfile
@@ -5,6 +5,7 @@ RUN yum update -y \
     epel-release \
     gcc-c++ \
     hwloc-devel \
+    llvm-toolset \
     ocl-icd-devel \
     sudo \
  && yum clean all \


### PR DESCRIPTION
Contributes to https://github.com/microsoft/LightGBM/issues/6509.

Proposes updating to `manylinux_2_28` for aarch64 builds. See https://github.com/pypa/manylinux for more details.