### PR TITLE
Install CMake from GitHub but not from cmake.org

### DIFF
--- a/images/manylinux_2_28_x86_64/Dockerfile
+++ b/images/manylinux_2_28_x86_64/Dockerfile
@@ -10,7 +10,8 @@ RUN yum update -y \
  && rm -rf /var/cache/yum
 
 # Install CMake
-RUN curl -sL https://cmake.org/files/v3.30/cmake-3.30.1-linux-x86_64.sh -o cmake.sh \
+ARG CMAKE_VER=3.30.1
+RUN curl -sL https://github.com/Kitware/CMake/releases/download/v${CMAKE_VER}/cmake-${CMAKE_VER}-linux-x86_64.sh -o cmake.sh \
  && chmod +x cmake.sh \
  && ./cmake.sh --prefix=/usr/local --exclude-subdir \
  && rm -f ./cmake.sh


### PR DESCRIPTION
This change allows to make CMake version to be an argument. Similarly to how it is done in LightGBM.
https://github.com/microsoft/LightGBM/blob/3175a91224b5d2d505131e9254e4bb24a76afbea/.ci/setup.sh#L45

Docker was built successfully with this change: https://github.com/guolinke/lightgbm-ci-docker/actions/runs/10220407237.